### PR TITLE
Switch from Control.Monad.Trans.List to list-t

### DIFF
--- a/portage-hs/portage-hs.cabal
+++ b/portage-hs/portage-hs.cabal
@@ -139,6 +139,7 @@ test-suite portage-hs-test
         , containers <0.8
         , directory <1.4
         , filepath <1.6
+        , list-t <1.1
         , QuickCheck <2.16
         , tasty <1.6
         , tasty-hunit <0.11

--- a/portage-hs/test/Types/GentooTests.hs
+++ b/portage-hs/test/Types/GentooTests.hs
@@ -7,7 +7,7 @@ module Types.GentooTests (gentooTests) where
 
 import Control.Applicative
 import Control.Monad.Trans.Class
-import Control.Monad.Trans.List
+import ListT
 import Data.Proxy
 import System.Directory
 import System.FilePath.Posix


### PR DESCRIPTION
Control.Monad.Trans.List has been removed from transformers-0.6, so tests can't compile. Moving to list-t solves this problem.