### PR TITLE
Moving from Parsec to Flatparse

### DIFF
--- a/.github/workflows/cabal-portage.yml
+++ b/.github/workflows/cabal-portage.yml
@@ -18,9 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ghc-version:
-          [ "9.0"
-          , "9.2"
-          , "9.4"
+          [ "9.4"
           , "9.6"
           , "9.8"
           , "9.10"

--- a/parsable-test/parsable-test.cabal
+++ b/parsable-test/parsable-test.cabal
@@ -1,9 +1,9 @@
 cabal-version:      3.0
 name:               parsable-test
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           Test functions for the parsable package
 
-tested-with:        GHC == { 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.1 }
+tested-with:        GHC == { 9.4.8, 9.6.7, 9.8.4, 9.10.1, 9.12.2 }
 
 description:
     Provides QuickCheck generators and HUnit assertions for testing
@@ -56,7 +56,8 @@ library
     -- other-extensions:
     build-depends:
         , base >=4.13 && <4.22
-        , parsable <0.2
+        , bytestring >=0.12 && <0.13
+        , parsable >=0.2 && <0.3
         , mtl >=2.2.2 && <2.4
         , stm >=2.5 && <2.6
         , tasty <1.6

--- a/parsable-test/src/Test/Parsable.hs
+++ b/parsable-test/src/Test/Parsable.hs
@@ -4,13 +4,13 @@ Module      : Test.Parsable
 Test functions for 'Parsable' and 'Printable'.
 -}
 
-{-# Language CPP #-}
-{-# Language DerivingVia #-}
-{-# Language FlexibleContexts #-}
-{-# Language LambdaCase #-}
-{-# Language ScopedTypeVariables #-}
-{-# Language TupleSections #-}
-{-# Language TypeApplications #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Test.Parsable
     (
@@ -35,19 +35,18 @@ module Test.Parsable
     , module Data.Void
     ) where
 
-import Control.Monad.STM
-import Control.Concurrent.STM.TChan
-import Data.ByteString (ByteString)
+import           Control.Concurrent.STM.TChan
+import           Control.Monad.STM
+import           Data.ByteString (ByteString)
 import Data.ByteString.Char8 (pack)
-import Data.Function (fix)
-import Data.Semigroup (Last(..))
-import Data.Typeable
-import Data.Void
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck hiding (checkCoverage)
-
-import Data.Parsable
+import           Data.Function                (fix)
+import           Data.Parsable
+import           Data.Semigroup               (Last (..))
+import           Data.Typeable
+import           Data.Void
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck        hiding (checkCoverage)
 
 -- | If a parse succeeds for the beginning of the input, but then fails, we
 --   choose the 'PartialParse' constructor. If the entire parse was successful,

--- a/parsable-test/src/Test/Parsable.hs
+++ b/parsable-test/src/Test/Parsable.hs
@@ -31,13 +31,14 @@ module Test.Parsable
     , checkParsable
     , checkCoverage
       -- * Re-exports
-    , ParseError
     , module Control.Monad.STM
     , module Data.Void
     ) where
 
 import Control.Monad.STM
 import Control.Concurrent.STM.TChan
+import Data.ByteString (ByteString)
+import Data.ByteString.Char8 (pack)
 import Data.Function (fix)
 import Data.Semigroup (Last(..))
 import Data.Typeable
@@ -46,7 +47,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck hiding (checkCoverage)
 
-import Data.Parsable hiding (label)
+import Data.Parsable
 
 -- | If a parse succeeds for the beginning of the input, but then fails, we
 --   choose the 'PartialParse' constructor. If the entire parse was successful,
@@ -65,7 +66,7 @@ data ParseCoverage
 -- | QuickCheck tests for any 'Parsable' type. Currently this only checks
 --   'parsableProp'.
 parsableQuickCheck :: forall proxy a.
-    ( Parsable a Identity () String
+    ( Parsable a PureMode String
     , Printable a
     , Arbitrary a
     , Eq a
@@ -81,14 +82,14 @@ parsableQuickCheck p = do
 -- | QuickCheck property that verifies the "round-trip law" of any type
 --   which is both 'Parsable' and 'Printable'.
 parsableProp :: forall a.
-    ( Parsable a Identity () String
+    ( Parsable a PureMode String
     , Printable a
     , Eq a
     , Show a
-    ) => TChan ParseError -> a -> Property
+    ) => TChan String -> a -> Property
 parsableProp c x = whenFail (printErrorTChan c) $ idempotentIOProperty $ do
     let s = toString x
-    let r = runCheckParsable @a s
+    let r = runCheckParsable @a (pack s)
     _ <- either (atomically . writeTChan c) (const (pure ())) r
 #if defined(VERBOSE_TESTS)
     pure $ label s $ r === Right (CompleteParse, x)
@@ -102,7 +103,7 @@ parsableProp c x = whenFail (printErrorTChan c) $ idempotentIOProperty $ do
 --
 --   * 'parsableAssertion'
 parsableHUnit :: forall proxy a.
-    ( Parsable a Identity () String
+    ( Parsable a PureMode String
     , Printable a
     , Show a
     ) => proxy a -> String -> TestTree
@@ -115,7 +116,7 @@ parsableHUnit p str = testCase (show str) $ parsableAssertion p str
 --   * 'parsableAssertion'
 --   * 'printableAssertion'
 printableHUnit :: forall a.
-    ( Parsable a Identity () String
+    ( Parsable a PureMode String
     , Printable a
     , Show a
     , Eq a) => a -> TestTree
@@ -128,11 +129,11 @@ printableHUnit x = testCase (show str) $ do
 --   converted back to a string. This HUnit assertion verifies that the
 --   resulting string is the same as the original.
 parsableAssertion :: forall proxy a.
-    ( Parsable a Identity () String
+    ( Parsable a PureMode String
     , Printable a
     , Show a
     ) => proxy a -> String -> Assertion
-parsableAssertion _ s = case runCheckParsable @a s of
+parsableAssertion _ s = case runCheckParsable @a (pack s) of
     Left e ->
         assertFailure $
             "Could not parse: " ++ s ++ "\n"
@@ -148,18 +149,18 @@ parsableAssertion _ s = case runCheckParsable @a s of
 --   parsed. This HUnit assertion verifies that the parse result is the same as
 --   the original value.
 printableAssertion :: forall a.
-    ( Parsable a Identity () String
+    ( Parsable a PureMode String
     , Printable a
     , Show a
     , Eq a
     ) => a -> Assertion
-printableAssertion x = ppAssertion f $ runCheckParsable (toString x)
+printableAssertion x = ppAssertion f $ runCheckParsable (pack . toString $ x)
     where f = assertEqual "parse result equals original" x
 
 ppAssertion ::
     ( Show a
     ) => (a -> Assertion)
-    -> Either ParseError (ParseCoverage, a)
+    -> Either String (ParseCoverage, a)
     -> Assertion
 ppAssertion f = \case
     Left e ->
@@ -172,34 +173,33 @@ ppAssertion f = \case
             ++ "Output: " ++ show p ++ "\n"
     Right (CompleteParse, x) -> f x
 
+extract :: Result String a -> Either String a
+extract (OK a _) = Right a
+extract (Err e) = Left e
+extract Fail = Left "Parsable Tests recoverable failure"
 
 -- | Parses a string as the given 'Parsable' value
 runCheckParsable
-    :: Parsable a Identity () String
-    => String
-    -> Either ParseError (ParseCoverage, a)
-runCheckParsable = runParser checkParsable () ""
+    :: Parsable a PureMode String
+    => ByteString
+    -> Either String (ParseCoverage, a)
+runCheckParsable = extract . runParser checkParsable
 
 -- | Convenience function that runs 'checkCoverage' on a 'Parsable' parser.
 checkParsable
-    :: forall a s u m
-    .  (Stream s m Char, Parsable a m u s)
-    => ParsecT s u m (ParseCoverage, a)
-checkParsable = checkCoverage (parser <?> n)
-    where n = getParserName $ parserName @a @m @u @s
+    :: Parsable a st e => ParserT st e (ParseCoverage, a)
+checkParsable = checkCoverage parser
 
 -- | Run the specified parser, then return 'CompleteParse' if we are at
 --   'eof', otherwise 'PartialParse'.
-checkCoverage
-    :: Stream s m Char
-    => ParsecT s u m a
-    -> ParsecT s u m (ParseCoverage, a)
+checkCoverage ::
+    ParserT st e a
+    -> ParserT st e (ParseCoverage, a)
 checkCoverage p = do
     x <- p
-    (,x) <$> choice
-        [ CompleteParse <$ eof
-        , PartialParse  <$> lookAhead (anyToken `manyTill` eof)
-        ]
+    (,x) <$>
+      (CompleteParse <$ eof) <|>
+      (PartialParse  <$> traceRest)
 
 -- | Generator which takes two lists of predicates which specify valid
 --   characters.
@@ -219,9 +219,9 @@ wordGen wordStart wordRest = do
     anySat l x = or [f x | f <- l]
 
 
-printErrorTChan :: TChan ParseError -> IO ()
+printErrorTChan :: TChan String -> IO ()
 printErrorTChan c = fix $ \loop -> do
     me <- atomically $ tryReadTChan c
     case me of
-        Just e  -> putStrLn (show e) *> loop
+        Just e  -> print e *> loop
         Nothing -> pure ()

--- a/parsable/parsable.cabal
+++ b/parsable/parsable.cabal
@@ -1,79 +1,74 @@
-cabal-version:      3.0
-name:               parsable
-version:            0.2.0.0
-synopsis:           Parsable and Printable classes
-
-tested-with:        GHC == { 9.4.8, 9.6.7, 9.8.4, 9.10.1, 9.12.2 }
-
+cabal-version:   3.0
+name:            parsable
+version:         0.2.0.0
+synopsis:        Parsable and Printable classes
+tested-with:     GHC ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.1 || ==9.12.2
 description:
-    Provides the Parsable and Printable classes, which form a round-trip
-    equivalence between a data type and a String. Useful for types that
-    are generated directly from a String and need their internal
-    representation to be converted back to a String.
+  Provides the Parsable and Printable classes, which form a round-trip
+  equivalence between a data type and a String. Useful for types that
+  are generated directly from a String and need their internal
+  representation to be converted back to a String.
 
-homepage:           https://github.com/gentoo-haskell/cabal-portage/tree/main/parsable
-bug-reports:        https://github.com/gentoo-haskell/cabal-portage/issues
+homepage:
+  https://github.com/gentoo-haskell/cabal-portage/tree/main/parsable
 
-license:            AGPL-3.0-only
-license-file:       LICENSE
-author:             Gentoo Authors
-maintainer:         hololeap@protonmail.com
-
-copyright:          Copyright (C) 2022-2025 Gentoo Authors
-category:           Text
-extra-doc-files:
-    , CHANGELOG.md
+bug-reports:     https://github.com/gentoo-haskell/cabal-portage/issues
+license:         AGPL-3.0-only
+license-file:    LICENSE
+author:          Gentoo Authors
+maintainer:      hololeap@protonmail.com
+copyright:       Copyright (C) 2022-2025 Gentoo Authors
+category:        Text
+extra-doc-files: CHANGELOG.md
 
 source-repository head
-    type:           git
-    location:       https://github.com/gentoo-haskell/cabal-portage.git
-    branch:         main
-    subdir:         parsable
+  type:     git
+  location: https://github.com/gentoo-haskell/cabal-portage.git
+  branch:   main
+  subdir:   parsable
 
 flag pedantic
-    description: Enable -Werror
-    default:     False
-    manual:      True
+  description: Enable -Werror
+  default:     False
+  manual:      True
 
 common all
-    ghc-options:        -Wall
-                        -foptimal-applicative-do
-    if flag(pedantic)
-        ghc-options:    -Werror
+  ghc-options: -Wall -foptimal-applicative-do
+
+  if flag(pedantic)
+    ghc-options: -Werror
 
 library
-    import: all
-    exposed-modules:
-        , Data.Parsable
+  import:           all
+  exposed-modules:  Data.Parsable
+  other-extensions:
+    ConstrainedClassMethods
+    DefaultSignatures
+    DeriveTraversable
+    FlexibleContexts
+    FlexibleInstances
+    LambdaCase
+    TypeFamilies
 
-    other-extensions:
-        , ConstrainedClassMethods
-        , DefaultSignatures
-        , DeriveTraversable
-        , FlexibleContexts
-        , FlexibleInstances
-        , LambdaCase
-        , TypeFamilies
+  build-depends:
+    , base          >=4.13     && <4.22
+    , bytestring    >=0.12.0.0 && <0.13
+    , flatparse     >=0.5.2.0  && <0.5.3
+    , text          <2.2
+    , transformers  <0.7
 
-    build-depends:
-        , base >=4.13 && <4.22
-        , bytestring >=0.12.0.0 && <0.13
-        , flatparse >=0.5.2.0  && <0.5.3
-        , transformers <0.7
-        , text <2.2
-    hs-source-dirs:   src
-    default-language: Haskell2010
-
-    other-extensions:
-        , ConstrainedClassMethods
-        , DefaultSignatures
-        , DeriveGeneric
-        , DeriveTraversable
-        , DerivingVia
-        , FlexibleContexts
-        , FlexibleInstances
-        , GeneralizedNewtypeDeriving
-        , LambdaCase
-        , ScopedTypeVariables
-        , TypeApplications
-        , TypeFamilies
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  other-extensions:
+    ConstrainedClassMethods
+    DefaultSignatures
+    DeriveGeneric
+    DeriveTraversable
+    DerivingVia
+    FlexibleContexts
+    FlexibleInstances
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    ScopedTypeVariables
+    TypeApplications
+    TypeFamilies

--- a/parsable/parsable.cabal
+++ b/parsable/parsable.cabal
@@ -1,9 +1,9 @@
 cabal-version:      3.0
 name:               parsable
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           Parsable and Printable classes
 
-tested-with:        GHC == { 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.1 }
+tested-with:        GHC == { 9.4.8, 9.6.7, 9.8.4, 9.10.1, 9.12.2 }
 
 description:
     Provides the Parsable and Printable classes, which form a round-trip
@@ -57,7 +57,8 @@ library
 
     build-depends:
         , base >=4.13 && <4.22
-        , parsec <3.2
+        , bytestring >=0.12.0.0 && <0.13
+        , flatparse >=0.5.2.0  && <0.5.3
         , transformers <0.7
         , text <2.2
     hs-source-dirs:   src

--- a/parsable/src/Data/Parsable.hs
+++ b/parsable/src/Data/Parsable.hs
@@ -19,22 +19,22 @@ Look at the @Language Extensions@ section of the GHC documentation for
 instructions on how to use these extensions.
 -}
 
-{-# Language DataKinds #-}
-{-# Language DefaultSignatures #-}
-{-# Language DeriveDataTypeable #-}
-{-# Language DeriveGeneric #-}
-{-# Language DeriveTraversable #-}
-{-# Language DerivingVia #-}
-{-# Language FlexibleContexts #-}
-{-# Language FlexibleInstances #-}
-{-# Language GeneralizedNewtypeDeriving #-}
-{-# Language MultiParamTypeClasses #-}
-{-# Language OverloadedStrings #-}
-{-# Language QuantifiedConstraints #-}
-{-# Language ScopedTypeVariables #-}
-{-# Language TypeApplications #-}
-{-# Language TypeFamilies #-}
-{-# Language UndecidableInstances #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DefaultSignatures          #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuantifiedConstraints      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 module Data.Parsable
     (
@@ -68,22 +68,22 @@ module Data.Parsable
     , STMode
     ) where
 
-import Control.Applicative hiding (many)
-import Control.Monad
-import Control.Monad.ST (ST)
-import Control.Monad.Trans.Class
-import Data.ByteString (ByteString)
-import Data.Char hiding (isDigit)
-import Data.Data
-import Data.Functor.Identity
-import Data.String
-import Data.Text (Text, unpack)
-import FlatParse.Basic
-import FlatParse.Basic.Text
-import FlatParse.Common.Parser (IOMode, PureMode, STMode)
-import GHC.Exts (ZeroBitType)
-import GHC.Generics
-import Text.Read (readMaybe)
+import           Control.Applicative       hiding (many)
+import           Control.Monad
+import           Control.Monad.ST          (ST)
+import           Control.Monad.Trans.Class
+import           Data.ByteString           (ByteString)
+import           Data.Char                 hiding (isDigit)
+import           Data.Data
+import           Data.Functor.Identity
+import           Data.String
+import           Data.Text                 (Text, unpack)
+import           FlatParse.Basic
+import           FlatParse.Basic.Text
+import           FlatParse.Common.Parser   (IOMode, PureMode, STMode)
+import           GHC.Exts                  (ZeroBitType)
+import           GHC.Generics
+import           Text.Read                 (readMaybe)
 
 newtype ParserName a (st :: ZeroBitType) e = ParserName { getParserName :: String }
     deriving stock (Show, Eq, Ord)
@@ -104,7 +104,7 @@ instance (Read a, Typeable a)
     parser = (<?> "natural number") $ do
         ds <- some (satisfy isDigit)
         case readMaybe ds of
-            Just i -> pure $ NaturalParsable i
+            Just i  -> pure $ NaturalParsable i
             Nothing -> err $ "Could not parse as " ++ t ++ ": " ++ show ds
       where
         t = show $ typeRep $ Proxy @a
@@ -151,8 +151,7 @@ satisfyAny fs = satisfy $ \c -> or [f c | f <- fs]
 -- | Parsing of "words" which require a list of predicates for the first
 --   token, and a list of predicates for any remaining tokens. This always
 --   parses at least one token.
-wordAllowed
-    :: [Char -> Bool] -- ^ Tokens that start the word
+wordAllowed :: [Char -> Bool] -- ^ Tokens that start the word
     -> [Char -> Bool] -- ^ Any subsequent tokens
     -> ParserT st e [Char]
 wordAllowed beg rest = (:) <$> satisfyAny beg <*> many (satisfyAny rest)

--- a/parsable/src/Data/Parsable.hs
+++ b/parsable/src/Data/Parsable.hs
@@ -19,6 +19,7 @@ Look at the @Language Extensions@ section of the GHC documentation for
 instructions on how to use these extensions.
 -}
 
+{-# Language DataKinds #-}
 {-# Language DefaultSignatures #-}
 {-# Language DeriveDataTypeable #-}
 {-# Language DeriveGeneric #-}
@@ -40,7 +41,8 @@ module Data.Parsable
     -- * Parsing
       Parsable(..)
     , ParserName(..)
-    , runParsableT
+    , runParsableIO
+    , runParsableST
     , runParsable
     -- ** Wrappers
     , NaturalParsable(..)
@@ -59,66 +61,83 @@ module Data.Parsable
     , module Data.Char
     , module Data.Functor.Identity
     , module Data.String
-    , module Text.Parsec
-    , module Text.Parsec.Char
+    , module FlatParse.Basic
+    , module FlatParse.Basic.Text
+    , IOMode
+    , PureMode
+    , STMode
     ) where
 
 import Control.Applicative hiding (many)
 import Control.Monad
+import Control.Monad.ST (ST)
 import Control.Monad.Trans.Class
-import Data.Char
+import Data.ByteString (ByteString)
+import Data.Char hiding (isDigit)
 import Data.Data
 import Data.Functor.Identity
-import Data.Kind
 import Data.String
 import Data.Text (Text, unpack)
+import FlatParse.Basic
+import FlatParse.Basic.Text
+import FlatParse.Common.Parser (IOMode, PureMode, STMode)
+import GHC.Exts (ZeroBitType)
 import GHC.Generics
-import Text.Parsec
-import Text.Parsec.Char
 import Text.Read (readMaybe)
 
-newtype ParserName a s u (m :: Type -> Type) = ParserName { getParserName :: String }
+newtype ParserName a (st :: ZeroBitType) e = ParserName { getParserName :: String }
     deriving stock (Show, Eq, Ord)
     deriving newtype IsString
 
 -- | Represents types that have a valid Parsec parser.
-class Parsable a (m :: Type -> Type) u s where
-    parser :: ParsecT s u m a
-    parserName :: ParserName a s u m
+class Parsable a (st :: ZeroBitType) e where
+    parser :: ParserT st e a
+    parserName :: ParserName a st e
     {-# Minimal parser, parserName #-}
 
 newtype NaturalParsable a = NaturalParsable
     { unwrapNaturalParsable :: a }
 
-instance (Stream s m Char, Read a, Typeable a)
-    => Parsable (NaturalParsable a) m u s where
+instance (Read a, Typeable a)
+    => Parsable (NaturalParsable a) st String where
     parserName = "natural number"
     parser = (<?> "natural number") $ do
         ds <- some (satisfy isDigit)
         case readMaybe ds of
             Just i -> pure $ NaturalParsable i
-            Nothing -> fail $ "Could not parse as " ++ t ++ ": " ++ show ds
+            Nothing -> err $ "Could not parse as " ++ t ++ ": " ++ show ds
       where
         t = show $ typeRep $ Proxy @a
 
--- | Convenience function to run a 'Parsable' parser.
-runParsableT :: forall a m s. (Stream s m Char, Parsable a m () s)
-    => String -> s -> m (Either ParseError a)
-runParsableT = runParserT (parser <?> n) ()
-    where n = getParserName $ parserName @a @m @() @s
+infix 0 <?>
+(<?>) :: ParserT st String a -> String -> ParserT st String a
+(<?>) p e = withError p (\_ -> err e)
 
-runParsable :: forall a s. (Stream s Identity Char, Parsable a Identity () s)
-    => String -> s -> Either ParseError a
-runParsable = runParser (parser <?> n) ()
-    where n = getParserName $ parserName @a @Identity @() @s
+-- | Convenience function to run a 'Parsable' parser.
+runParsableIO :: forall a e. (Parsable a IOMode e)
+    => ByteString -> IO (Either e a)
+runParsableIO bs = extractResult <$> runParserIO parser bs
+
+runParsableST :: forall a e s. (Parsable a (STMode s) e)
+    => ByteString -> ST s (Either e a)
+runParsableST bs = extractResult <$> runParserST parser bs
+
+runParsable :: forall a e. (Parsable a PureMode e)
+    => ByteString -> Either e a
+runParsable = extractResult . runParser parser
+
+extractResult :: Result e a -> Either e a
+extractResult (OK a _) = Right a
+extractResult (Err e)  = Left e
+extractResult Fail     = Left (error "Result recoverable failure")
 
 -- | Pass a previously-parsed string to this function in order to attempt
 --   using 'read'. Produces proper error messages on failure.
-readParsec :: forall a s u m. (Typeable a, Read a) => String -> ParsecT s u m a
+readParsec :: forall a st. (Typeable a, Read a) => String -> ParserT st String a
 readParsec s = (<?> typeName ++ " (Read instance)") $
     case readMaybe s of
         Just x -> pure x
-        Nothing -> fail
+        Nothing -> err
             $  "unable to parse using "
             ++ typeName
             ++ " Read instance: "
@@ -126,16 +145,16 @@ readParsec s = (<?> typeName ++ " (Read instance)") $
     where typeName = show $ typeRep $ Proxy @a
 
 -- | Parse a token that satisfies any of the given predicates
-satisfyAny :: Stream s m Char => [Char -> Bool] -> ParsecT s u m Char
+satisfyAny :: [Char -> Bool] -> ParserT st e Char
 satisfyAny fs = satisfy $ \c -> or [f c | f <- fs]
 
 -- | Parsing of "words" which require a list of predicates for the first
 --   token, and a list of predicates for any remaining tokens. This always
 --   parses at least one token.
-wordAllowed :: Stream s m Char
-    => [Char -> Bool] -- ^ Tokens that start the word
+wordAllowed
+    :: [Char -> Bool] -- ^ Tokens that start the word
     -> [Char -> Bool] -- ^ Any subsequent tokens
-    -> ParsecT s u m [Char]
+    -> ParserT st e [Char]
 wordAllowed beg rest = (:) <$> satisfyAny beg <*> many (satisfyAny rest)
 
 -- | Types that can be converted back to a @String@.

--- a/portage-hs/portage-hs.cabal
+++ b/portage-hs/portage-hs.cabal
@@ -1,9 +1,9 @@
 cabal-version:      3.0
 name:               portage-hs
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           Data structures and functions for interacting with the Portage package manager
 
-tested-with:        GHC == { 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.1 }
+tested-with:        GHC == { 9.4.8, 9.6.7, 9.8.4, 9.10.1, 9.12.2 }
 
 description:
     Currently, this includes:
@@ -79,8 +79,8 @@ library
         , process <1.7
         , text <2.2
         , transformers <0.7
-        , parsable <0.2
-        , portage-hs-internal <0.2
+        , parsable >=0.2 && <0.3
+        , portage-hs-internal >=0.2 && <0.3
 
     other-extensions:
         , ApplicativeDo
@@ -99,7 +99,7 @@ library portage-hs-internal
     build-depends:
         , base >=4.13 && <4.22
         , hashable <1.6
-        , parsable <0.2
+        , parsable >= 0.2 && <0.3
     hs-source-dirs:   src-internal
     default-language: Haskell2010
     other-extensions:
@@ -131,10 +131,11 @@ test-suite portage-hs-test
     autogen-modules:
         , Paths_portage_hs
     build-depends:
-        , parsable <0.2
-        , parsable-test <0.2
-        , portage-hs <0.2
-        , portage-hs-internal <0.2
+        , bytestring >=0.12 && <0.13
+        , parsable >=0.2 && <0.3
+        , parsable-test >=0.2 && <0.3
+        , portage-hs >=0.2 && <0.3
+        , portage-hs-internal >=0.2 && <0.3
         , base >=4.13 && <4.22
         , conduit <1.4
         , containers <0.8

--- a/portage-hs/src-internal/Internal/Distribution/Portage/Types.hs
+++ b/portage-hs/src-internal/Internal/Distribution/Portage/Types.hs
@@ -15,6 +15,7 @@ Types for internal use
 {-# Language MultiParamTypeClasses #-}
 {-# Language OverloadedStrings #-}
 {-# Language ScopedTypeVariables #-}
+{-# Language TemplateHaskell #-}
 {-# Language TypeApplications #-}
 {-# Language TypeFamilies #-}
 {-# Language UndecidableInstances #-}
@@ -47,7 +48,7 @@ module Internal.Distribution.Portage.Types
     , FauxVersionNum(..)
     ) where
 
-import Control.Applicative (Alternative, some)
+import Control.Applicative (Alternative)
 import Data.Data (Data)
 import Data.Function (on)
 import Data.Hashable
@@ -66,7 +67,7 @@ newtype Category = Category
     deriving newtype (IsString, Printable)
     deriving anyclass Hashable
 
-instance Stream s m Char => Parsable Category m u s where
+instance Parsable Category st e where
     parserName = "portage category"
     parser = Category <$> wordAllowed wordStart wordRest
       where
@@ -88,7 +89,7 @@ newtype PkgName = PkgName
     deriving newtype (IsString, Printable)
     deriving anyclass Hashable
 
-instance forall m u s. Stream s m Char => Parsable PkgName m u s where
+instance Parsable PkgName st String where
     parserName = "portage package name"
     parser = PkgName <$> pkgParser wordStart wordRest
       where
@@ -139,9 +140,9 @@ instance IsList VersionNum where
 instance Printable VersionNum where
     toString = L.intercalate "." . NE.toList . fmap NE.toList . unwrapVersionNum
 
-instance Stream s m Char => Parsable VersionNum m u s where
+instance Parsable VersionNum st e where
     parserName = "portage version number"
-    parser = versionNumParser (`sepBy1` char '.') (NE.fromList <$>)
+    parser = versionNumParser (`sepBy1` ($(char '.'))) (NE.fromList <$>)
 
 newtype VersionLetter = VersionLetter
     { unwrapVersionLetter :: Char }
@@ -151,7 +152,7 @@ newtype VersionLetter = VersionLetter
 instance Printable VersionLetter where
     toString (VersionLetter l) = [l]
 
-instance Stream s m Char => Parsable VersionLetter m u s where
+instance Parsable VersionLetter st e where
     parserName = "portage version letter"
     parser = VersionLetter <$> satisfy isAsciiLower
 
@@ -172,16 +173,15 @@ instance Printable VersionSuffix where
         SuffixRC    -> "rc"
         SuffixP     -> "p"
 
-instance Stream s m Char => Parsable VersionSuffix m u s where
+instance Parsable VersionSuffix st e where
     parserName = "portage version suffix"
-    parser = choice
-        [ SuffixAlpha <$ try (string "alpha")
-        , SuffixBeta  <$ try (string "beta")
-        , SuffixPre   <$ try (string "pre")
-        , SuffixRC    <$ try (string "rc")
-        , SuffixP     <$ string "p"
-        ]
-
+    parser = $(switch [| case _ of
+                           "alpha" -> pure SuffixAlpha
+                           "beta"  -> pure SuffixBeta
+                           "pre"   -> pure SuffixPre
+                           "rc"    -> pure SuffixRC
+                           "p"     -> pure SuffixP
+                           |])
 newtype VersionSuffixNum = VersionSuffixNum
     { unwrapVersionSuffixNum :: NonEmpty Char }
     deriving stock (Show, Eq, Ord, Data, Generic)
@@ -190,7 +190,7 @@ newtype VersionSuffixNum = VersionSuffixNum
 instance Printable VersionSuffixNum where
     toString = NE.toList . unwrapVersionSuffixNum
 
-instance Stream s m Char => Parsable VersionSuffixNum m u s where
+instance Parsable VersionSuffixNum st e where
     parserName = "portage version suffix number"
     parser = VersionSuffixNum . NE.fromList <$> some (satisfy isDigit)
 
@@ -202,10 +202,10 @@ newtype VersionRevision = VersionRevision
 instance Printable VersionRevision where
     toString (VersionRevision r) = "r" ++ NE.toList r
 
-instance Stream s m Char => Parsable VersionRevision m u s where
+instance Parsable VersionRevision st e where
     parserName = "portage version revision"
     parser = do
-        _ <- char 'r'
+        _ <- $(char 'r')
         VersionRevision . NE.fromList <$> some (satisfy isDigit)
 
 data Version = Version
@@ -249,7 +249,7 @@ instance Printable Version where
       where
         suffixString (ss,sn) = "_" ++ toString ss ++ foldMap toString sn
 
-instance Stream s m Char => Parsable Version m u s where
+instance Parsable Version st e where
     parserName = "portage version"
     parser = versionParser parser
 
@@ -300,28 +300,30 @@ instance Printable ConstrainedDep where
             EqualAsterisk -> "="
             EqualIgnoreRevision -> "~"
 
-instance Stream s m Char => Parsable ConstrainedDep m u s where
+instance Parsable ConstrainedDep st String where
     parserName = "portage package with version constraint"
     parser = do
         o <- operParser
         c <- parser
-        _ <- char '/'
+        _ <- $(char '/')
         n <- parser
-        _ <- char '-'
+        _ <- $(char '-')
         v <- parser
-        o' <- option o $ try $ case o of
-            Equal -> EqualAsterisk <$ char '*'
-            _ -> char '*' *> fail "Unexpected asterisk (not Equal operator)"
-        s <- optionMaybe $ try $ string ":"  *> parser
-        r <- optionMaybe $ try $ string "::" *> parser
+        o' <- withOption (try $ case o of
+                                  Equal -> $(char '*')
+                                  _ -> $(char '*' ) >> err "Unexpected asterisk (not Equal operator)")
+                         (const $ pure EqualAsterisk)
+                         (pure o)
+        s <- optional $ $(string ":") *> parser
+        r <- optional $ $(string "::") *> parser
         pure $ ConstrainedDep o' c n v s r
       where
-        operParser = choice
-            [ char '>' *> option Greater (try (GreaterOrEqual <$ char '='))
-            , char '<' *> option Lesser (try (LesserOrEqual <$ char '='))
-            , Equal <$ char '='
-            , EqualIgnoreRevision <$ char '~'
-            ]
+        operParser = $(switch [| case _ of
+              ">" -> ($(char '=') >> pure GreaterOrEqual) <|> pure Greater
+              "<" -> ($(char '=') >> pure LesserOrEqual) <|> pure Lesser
+              "=" -> pure Equal
+              "~" -> pure EqualIgnoreRevision
+            |])
 
 toConstrainedDep :: Operator -> Package -> Maybe ConstrainedDep
 toConstrainedDep o (Package c n mv ms mr) =
@@ -383,11 +385,11 @@ instance Printable Slot where
         =  s
         ++ foldMap (\ss -> "/" ++ toString ss) mss
 
-instance Stream s m Char => Parsable Slot m u s where
+instance Parsable Slot st e where
     parserName = "portage slot"
     parser = do
         s <- slotParser
-        mss <- optionMaybe $ try $ char '/' *> parser
+        mss <- optional $ $(char '/') *> parser
         pure $ Slot s mss
 
 newtype SubSlot = SubSlot { unwrapSubSlot :: String }
@@ -395,11 +397,11 @@ newtype SubSlot = SubSlot { unwrapSubSlot :: String }
     deriving newtype (IsString, Printable)
     deriving anyclass Hashable
 
-instance Stream s m Char => Parsable SubSlot m u s where
+instance Parsable SubSlot st e where
     parserName = "portage sub-slot"
     parser = SubSlot <$> slotParser
 
-slotParser :: Stream s m Char => ParsecT s u m String
+slotParser :: ParserT st e String
 slotParser = wordAllowed wordStart wordRest
   where
     wordStart =
@@ -420,7 +422,7 @@ newtype Repository = Repository { unwrapRepository :: String }
     deriving newtype (IsString, Printable)
     deriving anyclass Hashable
 
-instance Stream s m Char => Parsable Repository m u s where
+instance Parsable Repository st String where
     parserName = "portage repository"
     parser = Repository <$> pkgParser wordStart wordRest
       where
@@ -452,15 +454,15 @@ instance Printable Package where
         ++ foldMap (\s -> ":"  ++ toString s) ms
         ++ foldMap (\r -> "::" ++ toString r) mr
 
-instance Stream s m Char => Parsable Package m u s where
+instance Parsable Package st String where
     parserName = "portage package"
     parser = do
         c <- parser
-        _ <- char '/'
+        _ <- $(char '/')
         n <- parser
-        v <- optionMaybe $ try $ string "-"  *> parser
-        s <- optionMaybe $ try $ string ":"  *> parser
-        r <- optionMaybe $ try $ string "::" *> parser
+        v <- optional $ $(string "-")  *> parser
+        s <- optional $ $(string ":")  *> parser
+        r <- optional $ $(string "::") *> parser
         pure $ Package c n v s r
 
 -- data EBuildFileName = EBuildFileName
@@ -497,7 +499,7 @@ newtype FauxVersion = FauxVersion
     deriving newtype Printable
     deriving anyclass Hashable
 
-instance Stream s m Char => Parsable FauxVersion m u s where
+instance Parsable FauxVersion st e where
     parserName = "faux portage version"
     parser = FauxVersion <$> versionParser (unwrapFauxVersionNum <$> parser)
 
@@ -510,77 +512,76 @@ newtype FauxVersionNum = FauxVersionNum
     deriving newtype Printable
     deriving anyclass Hashable
 
-instance Stream s m Char => Parsable FauxVersionNum m u s where
+instance Parsable FauxVersionNum st e where
     parserName = "faux portage version number"
     parser = FauxVersionNum <$> versionNumParser id pure
 
-versionParser :: Stream s m Char
-    => ParsecT s u m VersionNum -> ParsecT s u m Version
+versionParser :: ParserT st e VersionNum -> ParserT st e Version
 versionParser pn = do
         n <- pn
-        l <- optionMaybe $ try parser
+        l <- optional parser
         s <- many $ do
-            _ <- char '_'
+            _ <- $(char '_')
             ss <- parser
-            sn <- optionMaybe $ try parser
+            sn <- optional parser
             pure (ss, sn)
-        r <- optionMaybe $ try $ string "-" *> parser
+        r <- optional $ $(string "-") *> parser
         pure $ Version n l s r
 
-versionNumParser :: Stream s m Char
-    => (ParsecT s u m [Char] -> ParsecT s u m [a])
+sepBy1 :: ParserT st e a -> ParserT st e sep -> ParserT st e [a]
+sepBy1 p sep = do
+  x <- p
+  xs <- many (sep >> p)
+  pure (x : xs)
+
+versionNumParser ::
+    (ParserT st e [Char] -> ParserT st e [a])
     -> (NonEmpty a -> NonEmpty (NonEmpty Char))
-    -> ParsecT s u m VersionNum
+    -> ParserT st e VersionNum
 versionNumParser f g = do
     ns <- f $ some $ satisfy isDigit
     pure $ VersionNum $ g $ NE.fromList ns
 
 -- | Both 'PkgName' and 'Repository' have similar parsers
-pkgParser :: forall s u m. Stream s m Char
-    => [Char -> Bool]
+pkgParser :: forall st.
+    [Char -> Bool]
     -> [Char -> Bool]
-    -> ParsecT s u m String
+    -> ParserT st String String
 pkgParser wordStart wordRest = (:) <$> satisfyAny wordStart <*> goOrEnd
   where
-    goOrEnd :: ParsecT s u m String
+    goOrEnd :: ParserT st String String
     goOrEnd = try go <|> end
 
     -- If 'fauxV' gives back a 'Nothing', it means the wole parse ended with
     -- a Version string and we need to throw the error 'e'.
-    go :: ParsecT s u m String
+    go :: ParserT st String String
     go = do
-        m <- choice
-            [ try fauxV
-            , Just <$> nextChar -- 'fauxV' did not match at all :)
-            ]
+        m <- fauxV <|> (Just <$> nextChar)
         maybe e pure m
 
     -- Check for a hyphen followed by something that parses as a 'FauxVersion'.
     -- If this is matched, but there isn't a successful 'go' parser after it,
     -- the parser aborts.
-    fauxV :: ParsecT s u m (Maybe String)
+    fauxV :: ParserT st String (Maybe String)
     fauxV = do
-        h <- char '-'
+        $(char '-')
         v <- parser @FauxVersion
-        choice
-            [ try $ do
+        (do
                 rest <- go -- Don't accept 'end' as a choice at this point
-                pure $ Just $ h : toString v ++ rest
-            , abort
-            ]
+                pure $ Just $ '-' : toString v ++ rest) <|> abort
 
-    nextChar :: ParsecT s u m String
+    nextChar :: ParserT st String String
     nextChar = do
         c <- satisfyAny wordRest
         rest <- goOrEnd
         pure $ c : rest
 
-    end :: ParsecT s u m String
+    end :: ParserT st e String
     end = pure ""
 
     -- 'show' is used here to wrap the string in quotes
-    e :: ParsecT s u m String
-    e = fail $
+    e :: ParserT st String String
+    e = err $ 
             "ends in a hyphen followed by anything "
             ++ "matching the version syntax"
 

--- a/portage-hs/src-internal/Internal/Distribution/Portage/Types.hs
+++ b/portage-hs/src-internal/Internal/Distribution/Portage/Types.hs
@@ -4,21 +4,21 @@ Module      : Distribution.Portage.Internal.Types
 Types for internal use
 -}
 
-{-# Language DeriveAnyClass #-}
-{-# Language DeriveDataTypeable #-}
-{-# Language DeriveGeneric #-}
-{-# Language DerivingVia #-}
-{-# Language FlexibleContexts #-}
-{-# Language FlexibleInstances #-}
-{-# Language GeneralizedNewtypeDeriving #-}
-{-# Language LambdaCase #-}
-{-# Language MultiParamTypeClasses #-}
-{-# Language OverloadedStrings #-}
-{-# Language ScopedTypeVariables #-}
-{-# Language TemplateHaskell #-}
-{-# Language TypeApplications #-}
-{-# Language TypeFamilies #-}
-{-# Language UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 module Internal.Distribution.Portage.Types
     (
@@ -48,18 +48,18 @@ module Internal.Distribution.Portage.Types
     , FauxVersionNum(..)
     ) where
 
-import Control.Applicative (Alternative)
-import Data.Data (Data)
-import Data.Function (on)
-import Data.Hashable
-import qualified Data.List as L
-import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NE
-import GHC.Exts (IsList(..))
-import GHC.Generics (Generic)
-import GHC.Natural (Natural)
+import           Control.Applicative (Alternative)
+import           Data.Data           (Data)
+import           Data.Function       (on)
+import           Data.Hashable
+import qualified Data.List           as L
+import           Data.List.NonEmpty  (NonEmpty (..))
+import qualified Data.List.NonEmpty  as NE
+import           GHC.Exts            (IsList (..))
+import           GHC.Generics        (Generic)
+import           GHC.Natural         (Natural)
 
-import Data.Parsable
+import           Data.Parsable
 
 newtype Category = Category
     { unwrapCategory :: String }
@@ -127,7 +127,7 @@ instance Ord VersionNum where
             xs -> (False, xs)
           where
             skipTrailing0s '0' [] = []
-            skipTrailing0s c cs = c:cs
+            skipTrailing0s c cs   = c:cs
 
         toNat :: NonEmpty Char -> Natural
         toNat = read . toList
@@ -209,8 +209,8 @@ instance Parsable VersionRevision st e where
         VersionRevision . NE.fromList <$> some (satisfy isDigit)
 
 data Version = Version
-    { getVersionNum :: VersionNum
-    , getVersionLetter :: Maybe VersionLetter
+    { getVersionNum      :: VersionNum
+    , getVersionLetter   :: Maybe VersionLetter
     , getVersionSuffixes :: [(VersionSuffix, Maybe VersionSuffixNum)]
     , getVersionRevision :: Maybe VersionRevision
     } deriving stock (Show, Eq, Data, Generic)
@@ -288,16 +288,16 @@ instance Printable ConstrainedDep where
       where
         asterisk = case o of
             EqualAsterisk -> "*"
-            _ -> ""
+            _             -> ""
 
         operStr :: String
         operStr = case o of
-            Lesser -> "<"
-            LesserOrEqual -> "<="
-            Greater -> ">"
-            GreaterOrEqual -> ">="
-            Equal -> "="
-            EqualAsterisk -> "="
+            Lesser              -> "<"
+            LesserOrEqual       -> "<="
+            Greater             -> ">"
+            GreaterOrEqual      -> ">="
+            Equal               -> "="
+            EqualAsterisk       -> "="
             EqualIgnoreRevision -> "~"
 
 instance Parsable ConstrainedDep st String where
@@ -361,9 +361,9 @@ doesConstraintMatch (ConstrainedDep co cc cn cv cs cr) (Package pc pn pv ps pr)
                         (toList (getVersionNum cv))
                         (toList (getVersionNum v))
   where
-    checkEqAst [] [] = True
-    checkEqAst (_cv:_cvs) [] = False
-    checkEqAst [] (_v:_vs) = True
+    checkEqAst [] []            = True
+    checkEqAst (_cv:_cvs) []    = False
+    checkEqAst [] (_v:_vs)      = True
     checkEqAst (cv':cvs) (v:vs) = cv' == v && checkEqAst cvs vs
 
     checkConstrained :: Eq a => Maybe a -> Maybe a -> Bool
@@ -371,7 +371,7 @@ doesConstraintMatch (ConstrainedDep co cc cn cv cs cr) (Package pc pn pv ps pr)
         -- Constraint specifies, package provides
         (Just x1, Just x2) -> x1 == x2
         -- Package does not specifiy
-        _ -> True
+        _                  -> True
 
 data Slot = Slot
     { unwrapSlot :: String

--- a/portage-hs/test/Emerge/ParserTests.hs
+++ b/portage-hs/test/Emerge/ParserTests.hs
@@ -1,32 +1,31 @@
-{-# Language LambdaCase #-}
+{-# LANGUAGE LambdaCase #-}
+
 
 module Emerge.ParserTests
     ( parserTests
     ) where
 
-import Conduit
-import Data.Set (Set)
-import qualified Data.Set as S
-import qualified Data.Text.IO as T
+import           Conduit
+import           Data.Set                           (Set)
+import qualified Data.Set                           as S
+import qualified Data.Text.IO                       as T
 import Data.Text.Encoding (encodeUtf8)
-import System.Directory
-import System.FilePath
-import Test.Tasty
-import Test.Tasty.HUnit
+import           System.Directory
+import           System.FilePath
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
-import Data.Parsable
-import Distribution.Portage.Types
-import Distribution.Portage.Emerge
-import Distribution.Portage.Emerge.Parser
-import Test.Parsable
+import           Data.Parsable
+import           Distribution.Portage.Emerge
+import           Distribution.Portage.Emerge.Parser
+import           Distribution.Portage.Types
+import           Test.Parsable
 
-import Paths_portage_hs (getDataFileName)
+import           Paths_portage_hs                   (getDataFileName)
 
 parserTests :: IO TestTree
 parserTests = do
-    stdouts <- emergeStdOuts
-    pure $ testGroup "test against recorded emerge output" $
-        map (uncurry stdoutTest) stdouts
+    testGroup "test against recorded emerge output" . map (uncurry stdoutTest) <$> emergeStdOuts
 
 stdoutTest :: FilePath -> StdOut -> TestTree
 stdoutTest d o =

--- a/portage-hs/test/Types/UnitTests.hs
+++ b/portage-hs/test/Types/UnitTests.hs
@@ -7,6 +7,7 @@ module Types.UnitTests (unitTests) where
 import Data.List.NonEmpty (NonEmpty(..))
 import Test.Tasty
 import Test.Tasty.HUnit
+import Data.ByteString.Char8 (pack)
 
 import Internal.Distribution.Portage.Types
 import Data.Parsable
@@ -204,11 +205,17 @@ unitTests = testGroup "unit tests"
 
 -- Takes a string and an expected result, and creates a TestTree from them
 parserTest :: forall a.
-    ( Parsable a Identity () String
+    ( Parsable a PureMode String
     , Eq a
     , Show a
     ) => String
     -> a
     -> TestTree
 parserTest s x = testCase (show s) $
-    Right (CompleteParse, x) @=? runParser (checkParsable @a) () "" s
+    Right (CompleteParse, x) @=? extract (runParser (checkParsable @a) (pack s))
+      where
+        extract :: Result String (ParseCoverage, a) -> Either String (ParseCoverage, a)
+        extract (OK a _) = Right a
+        extract (Err e) = Left e
+        extract Fail = Left "Unit Tests recoverable failure"
+

--- a/portage-hs/test/Types/ValidityTests.hs
+++ b/portage-hs/test/Types/ValidityTests.hs
@@ -1,11 +1,12 @@
-{-# Language LambdaCase #-}
-{-# Language TypeApplications #-}
-{-# Language ViewPatterns #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns     #-}
 
 {-# Options_GHC -Wno-orphans #-}
 
 module Types.ValidityTests (validityTests) where
 
+import           Data.ByteString.Char8               (pack)
 import Data.Either (isLeft)
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -256,7 +257,7 @@ pkgGen
   where
     nonVersion =
         wordGen wordStart wordRest
-            `suchThat` (isLeft . runParsable @Version "")
+            `suchThat` (isLeft . runParsable @Version . pack) 
 
     -- Don't start with @pure ""@ or it will end up creating a string that
     -- starts with @'-'@ (an invalid Package/Repository string)

--- a/portage-hs/test/Types/ValidityTests.hs
+++ b/portage-hs/test/Types/ValidityTests.hs
@@ -7,17 +7,17 @@
 module Types.ValidityTests (validityTests) where
 
 import           Data.ByteString.Char8               (pack)
-import Data.Either (isLeft)
-import qualified Data.List as L
-import qualified Data.List.NonEmpty as NE
-import Data.Proxy
-import GHC.Natural
-import Test.QuickCheck
-import Test.Tasty
+import           Data.Either                         (isLeft)
+import qualified Data.List                           as L
+import qualified Data.List.NonEmpty                  as NE
+import           Data.Proxy
+import           GHC.Natural
+import           Test.QuickCheck
+import           Test.Tasty
 
-import Data.Parsable
-import Test.Parsable
-import Internal.Distribution.Portage.Types
+import           Data.Parsable
+import           Internal.Distribution.Portage.Types
+import           Test.Parsable
 
 
 validityTests :: STM TestTree
@@ -225,8 +225,7 @@ instance Arbitrary FauxVersionNum where
 -- > It [...] must not end in a hyphen followed by anything matching the
 -- > version syntax described in section 3.2.
 instance Arbitrary FauxVersion where
-    arbitrary = fmap FauxVersion $ Version
-        <$> (unwrapFauxVersionNum <$> arbitrary)
+    arbitrary = fmap FauxVersion $ (Version . unwrapFauxVersionNum <$> arbitrary)
         <*> liftArbitrary arbitrary
         <*> liftArbitrary (liftArbitrary arbitrary)
         <*> liftArbitrary arbitrary


### PR DESCRIPTION
As suggested by @hololeap, this moves parsing from Parsec to FlatParse.

It passes all tests, but, as FlatParse and Parser have a fairly different API, there are some API changes here too.